### PR TITLE
Fix bugs

### DIFF
--- a/lib/multiline/array.rb
+++ b/lib/multiline/array.rb
@@ -1,7 +1,8 @@
 module Multiline
   class Array < ::Array
     def join(sep = $,, align: :center)
-      buf = Multiline::String.new
+      max_row = self.max{|str| str.row }.row
+      buf = Multiline::String.new("", max_row)
       self.each_with_index do |str, index|
         case str
         when ::String

--- a/lib/multiline/string.rb
+++ b/lib/multiline/string.rb
@@ -1,9 +1,9 @@
 module Multiline
   class String
     attr_reader :row, :col, :buf
-    def initialize(str = "")
+    def initialize(str = "", buf_row = nil)
       @buf = str.split(/\n/)
-      @row = @buf.count || 0
+      @row = [@buf.length, buf_row].compact.max rescue binding.irb
       @col = @buf.map{|line| Unicode::DisplayWidth.of(line,
                                                       Multiline.config.display_width_ambiguous,
                                                       Multiline.config.display_width_overwrite) }.max || 0
@@ -20,6 +20,8 @@ module Multiline
 
     def concat(*arguments, align: :center)
       arguments.each do |arg|
+        org_col = @col
+        org_row = @row
         @col += arg.col
         @row = [@row, arg.row].max
 
@@ -39,7 +41,7 @@ module Multiline
           end
 
           for index in 0...row do
-            buf[index] ||= ""
+            buf[index] ||= " " * org_col
             line = buf[index]
             if index >= start_row && index < end_row
               line.concat(arg.buf[index - start_row])

--- a/spec/multiline/array_spec.rb
+++ b/spec/multiline/array_spec.rb
@@ -41,5 +41,45 @@ c  ,333
 EOF
       )
     }
+
+    it {
+text = <<EOF
+aaa
+bbb
+EOF
+
+text2 = <<EOF
+1
+22
+333
+EOF
+      array = Multiline::Array.new
+      array << Multiline::String.new(text)
+      array << Multiline::String.new(text2)
+
+      expect(array.join(",", align: :center).to_s).to eq(
+<<EOF
+aaa 1  
+bbb,22 
+    333
+EOF
+      )
+
+      expect(array.join(",", align: :top).to_s).to eq(
+<<EOF
+aaa,1  
+bbb 22 
+    333
+EOF
+      )
+
+      expect(array.join(",", align: :bottom).to_s).to eq(
+<<EOF
+    1  
+aaa 22 
+bbb,333
+EOF
+      )
+    }
   end
 end

--- a/spec/multiline/string_spec.rb
+++ b/spec/multiline/string_spec.rb
@@ -79,6 +79,29 @@ EOF
     it {
       text = Multiline::String.new(text_1)
       text2 = Multiline::String.new(text_2)
+      expect(text2.concat(text, align: :top)).to eq(
+<<EOF
+aaa11111
+bbb222  
+ccc333  
+   44   
+   5    
+EOF
+    )
+      expect(text2.buf).to eq([
+        "aaa11111",
+        "bbb222  ",
+        "ccc333  ",
+        "   44   ",
+        "   5    "
+      ])
+      expect(text2.col).to eq(8)
+      expect(text2.row).to eq(5)
+    }
+
+    it {
+      text = Multiline::String.new(text_1)
+      text2 = Multiline::String.new(text_2)
       expect(text.concat(text2, align: :top)).to eq(
 <<EOF
 11111aaa


### PR DESCRIPTION
* When the string before merging has fewer lines than the string after merging, the space will be inserted for the number of characters before merging.
* When joining multiple strings with Multiline::Array#join, the string is now created according to the string with the most lines.